### PR TITLE
Add basic order management with cart

### DIFF
--- a/app/controllers/cart_controller.rb
+++ b/app/controllers/cart_controller.rb
@@ -1,0 +1,28 @@
+class CartController < ApplicationController
+  def show
+    @cart = current_cart
+    @products = Product.where(id: @cart.keys)
+  end
+
+  def add
+    product_id = params[:product_id].to_s
+    cart = current_cart
+    cart[product_id] = (cart[product_id] || 0) + 1
+    session[:cart] = cart
+    redirect_to cart_path
+  end
+
+  def remove
+    product_id = params[:product_id].to_s
+    cart = current_cart
+    cart.delete(product_id)
+    session[:cart] = cart
+    redirect_to cart_path
+  end
+
+  private
+
+  def current_cart
+    session[:cart] ||= {}
+  end
+end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,0 +1,37 @@
+class OrdersController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_cart, only: [:new, :create]
+
+  def index
+    @orders = current_user.orders.includes(line_items: :product)
+  end
+
+  def show
+    @order = current_user.orders.includes(line_items: :product).find(params[:id])
+  end
+
+  def new
+    @order = current_user.orders.new
+    @products = Product.where(id: @cart.keys)
+  end
+
+  def create
+    @order = current_user.orders.new(state: 'pending')
+    @cart.each do |product_id, quantity|
+      @order.line_items.build(product_id: product_id, quantity: quantity)
+    end
+    if @order.save
+      session[:cart] = {}
+      redirect_to @order, notice: 'Order was successfully created.'
+    else
+      @products = Product.where(id: @cart.keys)
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_cart
+    @cart = session[:cart] || {}
+  end
+end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,0 +1,5 @@
+class ProductsController < ApplicationController
+  def index
+    @products = Product.all
+  end
+end

--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -1,0 +1,6 @@
+class LineItem < ApplicationRecord
+  belongs_to :order
+  belongs_to :product
+
+  validates :quantity, numericality: { greater_than: 0 }
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,0 +1,7 @@
+class Order < ApplicationRecord
+  belongs_to :user
+  has_many :line_items, dependent: :destroy
+  has_many :products, through: :line_items
+
+  validates :state, presence: true
+end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -2,6 +2,8 @@ class Product < ApplicationRecord
   acts_as_tenant(:company)
   belongs_to :company
   has_many_attached :images
+
+  has_many :line_items, dependent: :destroy
   
   validates :name, :price_cents, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,6 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  has_many :orders, dependent: :destroy
 end

--- a/app/views/cart/show.html.erb
+++ b/app/views/cart/show.html.erb
@@ -1,0 +1,14 @@
+<h1>Your Cart</h1>
+<% if @cart.empty? %>
+  <p>Your cart is empty.</p>
+<% else %>
+  <ul>
+    <% @products.each do |product| %>
+      <li>
+        <%= product.name %> (<%= @cart[product.id.to_s] %>)
+        <%= button_to 'Remove', remove_item_cart_path(product_id: product.id), method: :delete %>
+      </li>
+    <% end %>
+  </ul>
+  <%= link_to 'Checkout', new_order_path %>
+<% end %>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,0 +1,6 @@
+<h1>Orders</h1>
+<% @orders.each do |order| %>
+  <div>
+    <%= link_to "Order ##{order.id}", order_path(order) %> - <%= order.state %>
+  </div>
+<% end %>

--- a/app/views/orders/new.html.erb
+++ b/app/views/orders/new.html.erb
@@ -1,0 +1,13 @@
+<h1>Confirm Order</h1>
+<% if @cart.empty? %>
+  <p>Your cart is empty.</p>
+<% else %>
+  <ul>
+    <% @products.each do |product| %>
+      <li>
+        <%= product.name %> (<%= @cart[product.id.to_s] %>)
+      </li>
+    <% end %>
+  </ul>
+  <%= button_to 'Place Order', orders_path, method: :post %>
+<% end %>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -1,0 +1,7 @@
+<h1>Order <%= @order.id %></h1>
+<p>State: <%= @order.state %></p>
+<ul>
+  <% @order.line_items.each do |item| %>
+    <li><%= item.product.name %> (<%= item.quantity %>)</li>
+  <% end %>
+</ul>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -1,0 +1,10 @@
+<h1>Products</h1>
+<% @products.each do |product| %>
+  <div>
+    <%= product.name %> - <%= product.price_cents %> cents
+    <%= button_to 'Add to Cart', add_item_cart_path(product_id: product.id), method: :post %>
+  </div>
+<% end %>
+<p>
+  <%= link_to 'View Cart', cart_path %>
+</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,15 +2,14 @@ Rails.application.routes.draw do
   devise_for :users
   devise_for :companies
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
+  get 'up' => 'rails/health#show', as: :rails_health_check
 
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
-  get "up" => "rails/health#show", as: :rails_health_check
+  resource :cart, only: :show do
+    post 'add/:product_id', to: 'cart#add', as: :add_item
+    delete 'remove/:product_id', to: 'cart#remove', as: :remove_item
+  end
 
-  # Render dynamic PWA files from app/views/pwa/* (remember to link manifest in application.html.erb)
-  # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
-  # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
-
-  # Defines the root path route ("/")
-  # root "posts#index"
+  resources :orders, only: [:index, :show, :new, :create]
+  resources :products, only: :index
+  root 'products#index'
 end

--- a/db/migrate/20250806005000_create_orders.rb
+++ b/db/migrate/20250806005000_create_orders.rb
@@ -1,0 +1,10 @@
+class CreateOrders < ActiveRecord::Migration[8.0]
+  def change
+    create_table :orders do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :state, null: false, default: 'pending'
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250806005100_create_line_items.rb
+++ b/db/migrate/20250806005100_create_line_items.rb
@@ -1,0 +1,11 @@
+class CreateLineItems < ActiveRecord::Migration[8.0]
+  def change
+    create_table :line_items do |t|
+      t.references :order, null: false, foreign_key: true
+      t.references :product, null: false, foreign_key: true
+      t.integer :quantity, null: false, default: 1
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_06_004512) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_06_005100) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -55,5 +55,26 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_06_004512) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  create_table "orders", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "state", default: "pending", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_orders_on_user_id"
+  end
+
+  create_table "line_items", force: :cascade do |t|
+    t.bigint "order_id", null: false
+    t.bigint "product_id", null: false
+    t.integer "quantity", default: 1, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["order_id"], name: "index_line_items_on_order_id"
+    t.index ["product_id"], name: "index_line_items_on_product_id"
+  end
+
+  add_foreign_key "line_items", "orders"
+  add_foreign_key "line_items", "products"
+  add_foreign_key "orders", "users"
   add_foreign_key "products", "companies"
 end


### PR DESCRIPTION
## Summary
- add Order and LineItem models with user, state and product references
- allow users to build orders from a session-based cart
- provide controller, views and routes for managing orders and cart

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec rspec` *(fails: command not found: rspec)*
- `bin/rails db:migrate` *(fails: Could not find rails-8.0.2, propshaft-1.2.1, pg-1.6.1-...)*

------
https://chatgpt.com/codex/tasks/task_e_6892ac7e5914832e874f4db255db8065