### PR TITLE
style: improve UI with responsive design

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -14,5 +14,9 @@
     --color-gray-700: #374151;
     --color-gray-800: #1f2937;
     --color-gray-900: #111827;
+    --color-green-600: #16a34a;
+    --color-green-700: #15803d;
+    --color-yellow-500: #eab308;
+    --color-yellow-600: #ca8a04;
   }
 }

--- a/app/components/layout/navbar_component.html.erb
+++ b/app/components/layout/navbar_component.html.erb
@@ -1,10 +1,10 @@
 <nav class="bg-white shadow">
-  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-    <div class="flex justify-between h-16">
-      <div class="flex-shrink-0 flex items-center">
+  <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+    <div class="flex flex-col items-center justify-between py-4 sm:h-16 sm:flex-row">
+      <div class="flex items-center">
         <%= link_to "Quick Build", root_path, class: "text-xl font-semibold text-indigo-600" %>
       </div>
-      <div class="flex space-x-4 items-center">
+      <div class="mt-4 flex flex-col items-center space-y-2 sm:mt-0 sm:flex-row sm:space-y-0 sm:space-x-4">
         <%= link_to 'Usuarios', new_user_session_path, class: 'text-gray-700 hover:text-indigo-600' %>
         <%= link_to 'Empresas', new_company_session_path, class: 'text-gray-700 hover:text-indigo-600' %>
         <%= link_to 'Productos', products_path, class: 'text-gray-700 hover:text-indigo-600' %>

--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -1,14 +1,16 @@
-<h1>Your Cart</h1>
-<% if @cart.empty? %>
-  <p>Your cart is empty.</p>
-<% else %>
-  <ul>
-    <% @products.each do |product| %>
-      <li>
-        <%= product.name %> (<%= @cart[product.id.to_s] %>)
-        <%= render Ui::ButtonComponent.new(label: 'Remove', path: remove_item_cart_path(product_id: product.id), method: :delete, variant: :danger) %>
-      </li>
-    <% end %>
-  </ul>
-  <%= render Ui::ButtonComponent.new(label: 'Checkout', path: new_order_path) %>
-<% end %>
+<h1 class="mb-6 text-2xl font-bold">Your Cart</h1>
+<div class="mx-auto max-w-md">
+  <% if @cart.empty? %>
+    <p>Your cart is empty.</p>
+  <% else %>
+    <ul class="mb-4 space-y-2">
+      <% @products.each do |product| %>
+        <li class="flex items-center justify-between rounded bg-white p-4 shadow">
+          <span><%= product.name %> (<%= @cart[product.id.to_s] %>)</span>
+          <%= render Ui::ButtonComponent.new(label: 'Remove', path: remove_item_cart_path(product_id: product.id), method: :delete, variant: :danger) %>
+        </li>
+      <% end %>
+    </ul>
+    <%= render Ui::ButtonComponent.new(label: 'Checkout', path: new_order_path) %>
+  <% end %>
+</div>

--- a/app/views/categories/_form.html.erb
+++ b/app/views/categories/_form.html.erb
@@ -1,9 +1,9 @@
-<%= form_with(model: category) do |form| %>
+<%= form_with(model: category, html: { class: 'space-y-4' }) do |form| %>
   <% if category.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(category.errors.count, "error") %> prohibited this category from being saved:</h2>
+    <div class="mb-4 rounded bg-red-100 p-4 text-red-800">
+      <h2 class="mb-2 font-semibold"><%= pluralize(category.errors.count, "error") %> prohibited this category from being saved:</h2>
 
-      <ul>
+      <ul class="list-disc pl-5">
         <% category.errors.full_messages.each do |message| %>
           <li><%= message %></li>
         <% end %>
@@ -12,11 +12,11 @@
   <% end %>
 
   <div>
-    <%= form.label :name %>
-    <%= form.text_field :name %>
+    <%= form.label :name, class: 'block text-sm font-medium text-gray-700' %>
+    <%= form.text_field :name, class: 'mt-1 w-full rounded border-gray-300 focus:border-indigo-500 focus:ring-indigo-500' %>
   </div>
 
   <div>
-    <%= render Ui::FormButtonComponent.new(form: form) %>
+    <%= render Ui::FormButtonComponent.new(form: form, label: category.persisted? ? 'Update Category' : 'Create Category') %>
   </div>
 <% end %>

--- a/app/views/categories/edit.html.erb
+++ b/app/views/categories/edit.html.erb
@@ -1,3 +1,5 @@
-<h1>Edit Category</h1>
-<%= render 'form', category: @category %>
-<%= link_to 'Back', categories_path %>
+<h1 class="mb-6 text-2xl font-bold">Edit Category</h1>
+<div class="mx-auto max-w-md rounded bg-white p-6 shadow">
+  <%= render 'form', category: @category %>
+</div>
+<p class="mt-4"><%= link_to 'Back', categories_path, class: 'text-indigo-600 hover:underline' %></p>

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -1,23 +1,27 @@
-<h1>Categories</h1>
+<h1 class="mb-6 text-2xl font-bold">Categories</h1>
 
-<table>
-  <thead>
-    <tr>
-      <th>Name</th>
-      <th colspan="3"></th>
-    </tr>
-  </thead>
-
-  <tbody>
-    <% @categories.each do |category| %>
+<div class="mb-4 overflow-x-auto">
+  <table class="min-w-full divide-y divide-gray-200">
+    <thead class="bg-gray-50">
       <tr>
-        <td><%= category.name %></td>
-        <td><%= link_to 'Show', category %></td>
-        <td><%= link_to 'Edit', edit_category_path(category) %></td>
-        <td><%= link_to 'Destroy', category, data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } %></td>
+        <th class="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Name</th>
+        <th class="px-4 py-2"></th>
+        <th class="px-4 py-2"></th>
+        <th class="px-4 py-2"></th>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
 
-<%= link_to 'New Category', new_category_path %>
+    <tbody class="divide-y divide-gray-200 bg-white">
+      <% @categories.each do |category| %>
+        <tr>
+          <td class="px-4 py-2"><%= category.name %></td>
+          <td class="px-4 py-2"><%= link_to 'Show', category, class: 'text-indigo-600 hover:underline' %></td>
+          <td class="px-4 py-2"><%= link_to 'Edit', edit_category_path(category), class: 'text-indigo-600 hover:underline' %></td>
+          <td class="px-4 py-2"><%= link_to 'Destroy', category, data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' }, class: 'text-red-600 hover:underline' %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>
+
+<p><%= render Ui::ButtonComponent.new(label: 'New Category', path: new_category_path) %></p>

--- a/app/views/categories/new.html.erb
+++ b/app/views/categories/new.html.erb
@@ -1,3 +1,5 @@
-<h1>New Category</h1>
-<%= render 'form', category: @category %>
-<%= link_to 'Back', categories_path %>
+<h1 class="mb-6 text-2xl font-bold">New Category</h1>
+<div class="mx-auto max-w-md rounded bg-white p-6 shadow">
+  <%= render 'form', category: @category %>
+</div>
+<p class="mt-4"><%= link_to 'Back', categories_path, class: 'text-indigo-600 hover:underline' %></p>

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -1,7 +1,10 @@
-<p>
-  <strong>Name:</strong>
-  <%= @category.name %>
-</p>
-
-<%= link_to 'Edit', edit_category_path(@category) %> |
-<%= link_to 'Back', categories_path %>
+<div class="mx-auto max-w-md rounded bg-white p-6 shadow">
+  <p class="mb-4">
+    <span class="font-semibold">Name:</span>
+    <%= @category.name %>
+  </p>
+  <div class="flex space-x-4">
+    <%= link_to 'Edit', edit_category_path(@category), class: 'text-indigo-600 hover:underline' %>
+    <%= link_to 'Back', categories_path, class: 'text-gray-600 hover:underline' %>
+  </div>
+</div>

--- a/app/views/companies/registrations/edit.html.erb
+++ b/app/views/companies/registrations/edit.html.erb
@@ -1,50 +1,54 @@
-<h2>Edit Company</h2>
+<div class="mx-auto max-w-md rounded bg-white p-6 shadow">
+  <h2 class="mb-6 text-2xl font-bold text-indigo-600">Edit Company</h2>
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: "space-y-4" }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+    <div>
+      <%= f.label :email, class: "block text-sm font-medium text-gray-700" %><br />
+      <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "mt-1 w-full rounded border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" %>
+    </div>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <div>
+      <%= f.label :name, class: "block text-sm font-medium text-gray-700" %><br />
+      <%= f.text_field :name, class: "mt-1 w-full rounded border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" %>
+    </div>
+
+    <div>
+      <%= f.label :address, class: "block text-sm font-medium text-gray-700" %><br />
+      <%= f.text_field :address, autocomplete: "street-address", class: "mt-1 w-full rounded border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" %>
+    </div>
+
+    <div>
+      <%= f.label :phone, class: "block text-sm font-medium text-gray-700" %><br />
+      <%= f.telephone_field :phone, class: "mt-1 w-full rounded border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" %>
+    </div>
+
+    <div>
+      <%= f.label :password, class: "block text-sm font-medium text-gray-700" %> <i>(leave blank if you don't want to change it)</i><br />
+      <%= f.password_field :password, autocomplete: "new-password", class: "mt-1 w-full rounded border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" %>
+    </div>
+
+    <div>
+      <%= f.label :password_confirmation, class: "block text-sm font-medium text-gray-700" %><br />
+      <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "mt-1 w-full rounded border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" %>
+    </div>
+
+    <div>
+      <%= f.label :current_password, class: "block text-sm font-medium text-gray-700" %> <i>(we need your current password to confirm your changes)</i><br />
+      <%= f.password_field :current_password, autocomplete: "current-password", class: "mt-1 w-full rounded border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" %>
+    </div>
+
+    <div>
+      <%= render Ui::FormButtonComponent.new(form: f, label: 'Update') %>
+    </div>
+  <% end %>
+
+  <h3 class="mt-6 text-lg font-semibold">Cancel my account</h3>
+
+  <div class="mt-2">
+    <%= render Ui::ButtonComponent.new(label: 'Cancel my account', path: registration_path(resource_name), method: :delete, data: { confirm: 'Are you sure?' }, variant: :danger) %>
   </div>
 
-  <div class="field">
-    <%= f.label :name %><br />
-    <%= f.text_field :name %>
-  </div>
+  <%= link_to "Back", :back, class: 'mt-4 inline-block text-indigo-600 hover:underline' %>
+</div>
 
-  <div class="field">
-    <%= f.label :address %><br />
-    <%= f.text_field :address, autocomplete: "street-address" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :phone %><br />
-    <%= f.telephone_field :phone %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
-  </div>
-
-  <div class="actions">
-    <%= render Ui::FormButtonComponent.new(form: f, label: 'Update') %>
-  </div>
-<% end %>
-
-<h3>Cancel my account</h3>
-
-<%= render Ui::ButtonComponent.new(label: 'Cancel my account', path: registration_path(resource_name), method: :delete, data: { confirm: 'Are you sure?' }, variant: :danger) %>
-
-<%= link_to "Back", :back %>

--- a/app/views/companies/registrations/new.html.erb
+++ b/app/views/companies/registrations/new.html.erb
@@ -1,41 +1,43 @@
-<h2>Sign up</h2>
+<div class="mx-auto max-w-md rounded bg-white p-6 shadow">
+  <h2 class="mb-6 text-2xl font-bold text-indigo-600">Sign up</h2>
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: "space-y-4" }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+    <div>
+      <%= f.label :email, class: "block text-sm font-medium text-gray-700" %><br />
+      <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "mt-1 w-full rounded border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" %>
+    </div>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <div>
+      <%= f.label :name, class: "block text-sm font-medium text-gray-700" %><br />
+      <%= f.text_field :name, class: "mt-1 w-full rounded border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" %>
+    </div>
+
+    <div>
+      <%= f.label :address, class: "block text-sm font-medium text-gray-700" %><br />
+      <%= f.text_field :address, autocomplete: "street-address", class: "mt-1 w-full rounded border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" %>
+    </div>
+
+    <div>
+      <%= f.label :phone, class: "block text-sm font-medium text-gray-700" %><br />
+      <%= f.telephone_field :phone, class: "mt-1 w-full rounded border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" %>
+    </div>
+
+    <div>
+      <%= f.label :password, class: "block text-sm font-medium text-gray-700" %>
+      <%= f.password_field :password, autocomplete: "new-password", class: "mt-1 w-full rounded border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" %>
+    </div>
+
+    <div>
+      <%= f.label :password_confirmation, class: "block text-sm font-medium text-gray-700" %>
+      <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "mt-1 w-full rounded border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" %>
+    </div>
+
+    <div>
+      <%= render Ui::FormButtonComponent.new(form: f, label: 'Sign up') %>
+    </div>
+  <% end %>
+  <div class="mt-4 text-center">
+    <%= render "devise/shared/links" %>
   </div>
-
-  <div class="field">
-    <%= f.label :name %><br />
-    <%= f.text_field :name %>
-  </div>
-
-  <div class="field">
-    <%= f.label :address %><br />
-    <%= f.text_field :address, autocomplete: "street-address" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :phone %><br />
-    <%= f.telephone_field :phone %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password %>
-    <%= f.password_field :password, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %>
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Sign up" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,6 +1,8 @@
-<h1>Orders</h1>
-<% @orders.each do |order| %>
-  <div>
-    <%= link_to "Order ##{order.id}", order_path(order) %> - <%= order.state %>
-  </div>
-<% end %>
+<h1 class="mb-6 text-2xl font-bold">Orders</h1>
+<div class="space-y-2">
+  <% @orders.each do |order| %>
+    <div class="rounded bg-white p-4 shadow">
+      <%= link_to "Order ##{order.id}", order_path(order), class: 'text-indigo-600 hover:underline' %> - <%= order.state %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/orders/new.html.erb
+++ b/app/views/orders/new.html.erb
@@ -1,13 +1,15 @@
-<h1>Confirm Order</h1>
-<% if @cart.empty? %>
-  <p>Your cart is empty.</p>
-<% else %>
-  <ul>
-    <% @products.each do |product| %>
-      <li>
-        <%= product.name %> (<%= @cart[product.id.to_s] %>)
-      </li>
-    <% end %>
-  </ul>
-  <%= render Ui::ButtonComponent.new(label: 'Place Order', path: orders_path, method: :post) %>
-<% end %>
+<h1 class="mb-6 text-2xl font-bold">Confirm Order</h1>
+<div class="mx-auto max-w-md">
+  <% if @cart.empty? %>
+    <p>Your cart is empty.</p>
+  <% else %>
+    <ul class="mb-4 space-y-2">
+      <% @products.each do |product| %>
+        <li class="rounded bg-white p-4 shadow">
+          <%= product.name %> (<%= @cart[product.id.to_s] %>)
+        </li>
+      <% end %>
+    </ul>
+    <%= render Ui::ButtonComponent.new(label: 'Place Order', path: orders_path, method: :post) %>
+  <% end %>
+</div>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -1,7 +1,9 @@
-<h1>Order <%= @order.id %></h1>
-<p>State: <%= @order.state %></p>
-<ul>
-  <% @order.line_items.each do |item| %>
-    <li><%= item.product.name %> (<%= item.quantity %>)</li>
-  <% end %>
-</ul>
+<div class="mx-auto max-w-md rounded bg-white p-6 shadow">
+  <h1 class="mb-4 text-2xl font-bold">Order <%= @order.id %></h1>
+  <p class="mb-4">State: <%= @order.state %></p>
+  <ul class="space-y-2">
+    <% @order.line_items.each do |item| %>
+      <li class="rounded bg-gray-50 p-2"><%= item.product.name %> (<%= item.quantity %>)</li>
+    <% end %>
+  </ul>
+</div>

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -1,9 +1,9 @@
-<%= form_with(model: product) do |form| %>
+<%= form_with(model: product, html: { class: 'space-y-4' }) do |form| %>
   <% if product.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(product.errors.count, "error") %> prohibited this product from being saved:</h2>
+    <div class="mb-4 rounded bg-red-100 p-4 text-red-800">
+      <h2 class="mb-2 font-semibold"><%= pluralize(product.errors.count, "error") %> prohibited this product from being saved:</h2>
 
-      <ul>
+      <ul class="list-disc pl-5">
         <% product.errors.full_messages.each do |message| %>
           <li><%= message %></li>
         <% end %>
@@ -12,26 +12,26 @@
   <% end %>
 
   <div>
-    <%= form.label :name %>
-    <%= form.text_field :name %>
+    <%= form.label :name, class: 'block text-sm font-medium text-gray-700' %>
+    <%= form.text_field :name, class: 'mt-1 w-full rounded border-gray-300 focus:border-indigo-500 focus:ring-indigo-500' %>
   </div>
 
   <div>
-    <%= form.label :price_cents %>
-    <%= form.number_field :price_cents %>
+    <%= form.label :price_cents, 'Price (cents)', class: 'block text-sm font-medium text-gray-700' %>
+    <%= form.number_field :price_cents, class: 'mt-1 w-full rounded border-gray-300 focus:border-indigo-500 focus:ring-indigo-500' %>
   </div>
 
   <div>
-    <%= form.label :description %>
-    <%= form.text_area :description %>
+    <%= form.label :description, class: 'block text-sm font-medium text-gray-700' %>
+    <%= form.text_area :description, class: 'mt-1 w-full rounded border-gray-300 focus:border-indigo-500 focus:ring-indigo-500' %>
   </div>
 
   <div>
-    <%= form.label :category_id, 'Category' %>
-    <%= form.collection_select :category_id, Category.all, :id, :name %>
+    <%= form.label :category_id, 'Category', class: 'block text-sm font-medium text-gray-700' %>
+    <%= form.collection_select :category_id, Category.all, :id, :name, {}, class: 'mt-1 w-full rounded border-gray-300 focus:border-indigo-500 focus:ring-indigo-500' %>
   </div>
 
   <div>
-    <%= render Ui::FormButtonComponent.new(form: form) %>
+    <%= render Ui::FormButtonComponent.new(form: form, label: product.persisted? ? 'Update Product' : 'Create Product') %>
   </div>
 <% end %>

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -1,3 +1,5 @@
-<h1>Edit Product</h1>
-<%= render 'form', product: @product %>
-<%= link_to 'Back', products_path %>
+<h1 class="mb-6 text-2xl font-bold">Edit Product</h1>
+<div class="mx-auto max-w-md rounded bg-white p-6 shadow">
+  <%= render 'form', product: @product %>
+</div>
+<p class="mt-4"><%= link_to 'Back', products_path, class: 'text-indigo-600 hover:underline' %></p>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -1,11 +1,12 @@
 <h1 class="mb-6 text-2xl font-bold">Productos</h1>
 
-<%= form_with url: products_path, method: :get, local: true, class: "mb-4 flex" do |form| %>
-  <%= form.text_field :query, value: params[:query], placeholder: "Buscar productos", class: "flex-grow mr-2 border rounded px-3 py-2" %>
+<%= form_with url: products_path, method: :get, local: true, class: "mb-4 flex flex-col sm:flex-row" do |form| %>
+  <%= form.text_field :query, value: params[:query], placeholder: "Buscar productos", class: "mb-2 flex-grow rounded border px-3 py-2 sm:mb-0 sm:mr-2 border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" %>
   <%= render Ui::FormButtonComponent.new(form: form, label: 'Buscar') %>
 <% end %>
 
-<table class="mb-4 min-w-full divide-y divide-gray-200">
+<div class="mb-4 overflow-x-auto">
+<table class="min-w-full divide-y divide-gray-200">
   <thead class="bg-gray-50">
     <tr>
       <th class="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Name</th>
@@ -31,7 +32,9 @@
       </tr>
     <% end %>
   </tbody>
+
 </table>
+</div>
 
 <p class="mb-4"><%= link_to 'View Cart', cart_path, class: 'text-indigo-600 hover:underline' %></p>
 

--- a/app/views/products/new.html.erb
+++ b/app/views/products/new.html.erb
@@ -1,3 +1,5 @@
-<h1>New Product</h1>
-<%= render 'form', product: @product %>
-<%= link_to 'Back', products_path %>
+<h1 class="mb-6 text-2xl font-bold">New Product</h1>
+<div class="mx-auto max-w-md rounded bg-white p-6 shadow">
+  <%= render 'form', product: @product %>
+</div>
+<p class="mt-4"><%= link_to 'Back', products_path, class: 'text-indigo-600 hover:underline' %></p>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -1,19 +1,10 @@
-<p>
-  <strong>Name:</strong>
-  <%= @product.name %>
-</p>
-<p>
-  <strong>Price:</strong>
-  <%= @product.price_cents %>
-</p>
-<p>
-  <strong>Category:</strong>
-  <%= @product.category.name if @product.category %>
-</p>
-<p>
-  <strong>Description:</strong>
-  <%= @product.description %>
-</p>
-
-<%= link_to 'Edit', edit_product_path(@product) %> |
-<%= link_to 'Back', products_path %>
+<div class="mx-auto max-w-md rounded bg-white p-6 shadow">
+  <p class="mb-2"><span class="font-semibold">Name:</span> <%= @product.name %></p>
+  <p class="mb-2"><span class="font-semibold">Price:</span> <%= number_to_currency(@product.price_cents / 100.0) %></p>
+  <p class="mb-2"><span class="font-semibold">Category:</span> <%= @product.category.name if @product.category %></p>
+  <p class="mb-4"><span class="font-semibold">Description:</span> <%= @product.description %></p>
+  <div class="flex space-x-4">
+    <%= link_to 'Edit', edit_product_path(@product), class: 'text-indigo-600 hover:underline' %>
+    <%= link_to 'Back', products_path, class: 'text-gray-600 hover:underline' %>
+  </div>
+</div>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -1,45 +1,49 @@
-<h2>Edit User</h2>
+<div class="mx-auto max-w-md rounded bg-white p-6 shadow">
+  <h2 class="mb-6 text-2xl font-bold text-indigo-600">Edit User</h2>
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: "space-y-4" }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+    <div>
+      <%= f.label :email, class: "block text-sm font-medium text-gray-700" %><br />
+      <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "mt-1 w-full rounded border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" %>
+    </div>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <div>
+      <%= f.label :address, class: "block text-sm font-medium text-gray-700" %><br />
+      <%= f.text_field :address, autocomplete: "street-address", class: "mt-1 w-full rounded border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" %>
+    </div>
+
+    <div>
+      <%= f.label :phone, class: "block text-sm font-medium text-gray-700" %><br />
+      <%= f.telephone_field :phone, class: "mt-1 w-full rounded border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" %>
+    </div>
+
+    <div>
+      <%= f.label :password, class: "block text-sm font-medium text-gray-700" %> <i>(leave blank if you don't want to change it)</i><br />
+      <%= f.password_field :password, autocomplete: "new-password", class: "mt-1 w-full rounded border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" %>
+    </div>
+
+    <div>
+      <%= f.label :password_confirmation, class: "block text-sm font-medium text-gray-700" %><br />
+      <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "mt-1 w-full rounded border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" %>
+    </div>
+
+    <div>
+      <%= f.label :current_password, class: "block text-sm font-medium text-gray-700" %> <i>(we need your current password to confirm your changes)</i><br />
+      <%= f.password_field :current_password, autocomplete: "current-password", class: "mt-1 w-full rounded border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" %>
+    </div>
+
+    <div>
+      <%= render Ui::FormButtonComponent.new(form: f, label: 'Update') %>
+    </div>
+  <% end %>
+
+  <h3 class="mt-6 text-lg font-semibold">Cancel my account</h3>
+
+  <div class="mt-2">
+    <%= render Ui::ButtonComponent.new(label: 'Cancel my account', path: registration_path(resource_name), method: :delete, data: { confirm: 'Are you sure?' }, variant: :danger) %>
   </div>
 
-  <div class="field">
-    <%= f.label :address %><br />
-    <%= f.text_field :address, autocomplete: "street-address" %>
-  </div>
+  <%= link_to "Back", :back, class: 'mt-4 inline-block text-indigo-600 hover:underline' %>
+</div>
 
-  <div class="field">
-    <%= f.label :phone %><br />
-    <%= f.telephone_field :phone %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
-  </div>
-
-  <div class="actions">
-    <%= render Ui::FormButtonComponent.new(form: f, label: 'Update') %>
-  </div>
-<% end %>
-
-<h3>Cancel my account</h3>
-
-<%= render Ui::ButtonComponent.new(label: 'Cancel my account', path: registration_path(resource_name), method: :delete, data: { confirm: 'Are you sure?' }, variant: :danger) %>
-
-<%= link_to "Back", :back %>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,36 +1,38 @@
-<h2>Sign up</h2>
+<div class="mx-auto max-w-md rounded bg-white p-6 shadow">
+  <h2 class="mb-6 text-2xl font-bold text-indigo-600">Sign up</h2>
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: "space-y-4" }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+    <div>
+      <%= f.label :email, class: "block text-sm font-medium text-gray-700" %>
+      <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "mt-1 w-full rounded border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" %>
+    </div>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <div>
+      <%= f.label :address, class: "block text-sm font-medium text-gray-700" %>
+      <%= f.text_field :address, autocomplete: "street-address", class: "mt-1 w-full rounded border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" %>
+    </div>
+
+    <div>
+      <%= f.label :phone, class: "block text-sm font-medium text-gray-700" %>
+      <%= f.telephone_field :phone, class: "mt-1 w-full rounded border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" %>
+    </div>
+
+    <div>
+      <%= f.label :password, class: "block text-sm font-medium text-gray-700" %>
+      <%= f.password_field :password, autocomplete: "new-password", class: "mt-1 w-full rounded border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" %>
+    </div>
+
+    <div>
+      <%= f.label :password_confirmation, class: "block text-sm font-medium text-gray-700" %>
+      <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "mt-1 w-full rounded border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" %>
+    </div>
+
+    <div>
+      <%= render Ui::FormButtonComponent.new(form: f, label: 'Sign up') %>
+    </div>
+  <% end %>
+  <div class="mt-4 text-center">
+    <%= render "devise/shared/links" %>
   </div>
-
-  <div class="field">
-    <%= f.label :address %><br />
-    <%= f.text_field :address, autocomplete: "street-address" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :phone %><br />
-    <%= f.telephone_field :phone %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password %>
-    <%= f.password_field :password, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %>
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Sign up" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -28,6 +28,14 @@ module.exports = {
           900: "var(--color-gray-900)",
         },
         red: { ...defaultTheme.colors.red },
+        green: {
+          600: "var(--color-green-600)",
+          700: "var(--color-green-700)",
+        },
+        yellow: {
+          500: "var(--color-yellow-500)",
+          600: "var(--color-yellow-600)",
+        },
       }
     }
   },


### PR DESCRIPTION
## Summary
- extend Tailwind palette with green and yellow shades
- restyle navbar, forms and tables for a professional responsive UI
- make cart and order pages mobile friendly

## Testing
- `bundle exec rubocop` *(fails: command not found)*
- `bin/rails test` *(fails: Could not find rails-8.0.2, propshaft-1.2.1, pg-1.6.1-x86_64-linux, pg-1.6.1, puma-6.6.1, importmap-rails-2.2.2, turbo-rails-2.0.16, stimulus-rails-1.3.4, tailwindcss-rails-4.3.0, jbuilder-2.13.0, view_component-3.20.0, solid_cache-1.0.7, solid_queue-1.2.1, solid_cable-3.0.11, bootsnap-1.18.6, kamal-2.7.0, thruster-0.1.15-x86_64-linux, thruster-0.1.15, debug-1.11.0, brakeman-7.1.0, rubocop-rails-omakase-1.1.0, web-console-4.2.1, capybara-3.40.0, selenium-webdriver-4.34.0, shoulda-matchers-6.5.0, devise-4.9.4, acts_as_tenant-1.0.1, pg_search-2.3.7, rspec-rails-8.0.1, factory_bot_rails-6.5.0, faker-3.5.2, actioncable-8.0.2, actionmailbox-8.0.2, actionmailer-8.0.2, actionpack-8.0.2, actiontext-8.0.2, actionview-8.0.2, activejob-8.0.2, activemodel-8.0.2, activerecord-8.0.2, activestorage-8.0.2, activesupport-8.0.2, railties-8.0.2, rack-3.2.0, nio4r-2.7.4, tailwindcss-ruby-4.1.11-x86_64-linux-gnu, tailwindcss-ruby-4.1.11, concurrent-ruby-1.3.5, method_source-1.1.0, fugit-1.11.1, thor-1.4.0, msgpack-1.8.0, base64-0.3.0, bcrypt_pbkdf-1.1.1, dotenv-3.1.8, ed25519-1.4.0, net-ssh-7.3.0, sshkit-1.24.0, zeitwerk-2.7.3, irb-1.15.2, reline-0.6.2, rubocop-1.79.2, rubocop-performance-1.25.0, rubocop-rails-2.32.0, bindex-0.8.1, addressable-2.8.7, matrix-0.4.3, mini_mime-1.1.5, nokogiri-1.18.9-x86_64-linux-gnu, rack-test-2.2.0, regexp_parser-2.11.0, xpath-3.2.0, logger-1.7.0, rexml-3.4.1, rubyzip-2.4.1, websocket-1.2.11, bcrypt-3.1.20, orm_adapter-0.5.0, responders-3.1.1, warden-1.2.9, rspec-core-3.13.5, rspec-expectations-3.13.5, rspec-mocks-3.13.5, rspec-support-3.13.4, factory_bot-6.5.4, i18n-1.14.7, websocket-driver-0.8.0, mail-2.8.1, rails-dom-testing-2.3.0, rack-session-2.1.1, rails-html-sanitizer-1.6.2, useragent-0.16.11, globalid-1.2.1, builder-3.3.0, erubi-1.13.1, marcel-1.0.4, benchmark-0.4.1, bigdecimal-3.2.2, connection_pool-2.5.3, drb-2.2.3, minitest-5.25.5, tzinfo-2.0.6, rackup-2.2.1, rake-13.3.0, et-orbi-1.2.11, raabro-1.4.0, net-scp-4.1.0, net-sftp-4.0.0, ostruct-0.6.3, rdoc-6.14.2, io-console-0.8.1, json-2.13.2, language_server-protocol-3.17.0.5, lint_roller-1.1.0, parallel-1.27.0, parser-3.3.9.0, rainbow-3.1.1, rubocop-ast-1.46.0, ruby-progressbar-1.13.0, unicode-display_width-3.1.4, public_suffix-6.0.2, diff-lcs-1.6.2, websocket-extensions-0.1.5, net-imap-0.5.9, loofah-2.24.1, erb-5.0.2, psych-5.2.6, ast-2.4.3, prism-1.4.0, unicode-emoji-4.0.4, crass-1.0.6, stringio-3.1.7`

------
https://chatgpt.com/codex/tasks/task_e_6892c53700ac832e9155c9fb65aefaf9