### PR TITLE
Add cart badge and live search

### DIFF
--- a/app/components/layout/navbar_component.html.erb
+++ b/app/components/layout/navbar_component.html.erb
@@ -8,6 +8,14 @@
         <%= link_to 'Usuarios', new_user_session_path, class: 'text-gray-700 hover:text-indigo-600' %>
         <%= link_to 'Empresas', new_company_session_path, class: 'text-gray-700 hover:text-indigo-600' %>
         <%= link_to 'Productos', products_path, class: 'text-gray-700 hover:text-indigo-600' %>
+        <%= link_to cart_path, class: 'relative inline-block text-gray-700 hover:text-indigo-600' do %>
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-1.35 2.7a1 1 0 00.9 1.3h12.2M16 16a2 2 0 11-4 0m6 0a2 2 0 11-4 0" />
+          </svg>
+          <% if cart_items_count.positive? %>
+            <span class="absolute -top-2 -right-2 rounded-full bg-indigo-600 px-1.5 text-xs text-white"><%= cart_items_count %></span>
+          <% end %>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,11 +4,23 @@ class ApplicationController < ActionController::Base
 
   before_action :configure_permitted_parameters, if: :devise_controller?
 
+  helper_method :current_cart, :cart_items_count
+
   protected
 
   def configure_permitted_parameters
     added_attrs = %i[address phone name]
     devise_parameter_sanitizer.permit(:sign_up, keys: added_attrs)
     devise_parameter_sanitizer.permit(:account_update, keys: added_attrs)
+  end
+
+  private
+
+  def current_cart
+    session[:cart] ||= {}
+  end
+
+  def cart_items_count
+    current_cart.values.sum
   end
 end

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -19,10 +19,4 @@ class CartsController < ApplicationController
     session[:cart] = cart
     redirect_to cart_path
   end
-
-  private
-
-  def current_cart
-    session[:cart] ||= {}
-  end
 end

--- a/app/javascript/controllers/search_controller.js
+++ b/app/javascript/controllers/search_controller.js
@@ -1,0 +1,10 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  search() {
+    clearTimeout(this.timeout)
+    this.timeout = setTimeout(() => {
+      this.element.requestSubmit()
+    }, 300)
+  }
+}

--- a/app/views/companies/sessions/new.html.erb
+++ b/app/views/companies/sessions/new.html.erb
@@ -1,0 +1,30 @@
+<div class="mx-auto max-w-md rounded bg-white p-6 shadow">
+  <h2 class="mb-6 text-2xl font-bold text-indigo-600">Sign in</h2>
+  <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "space-y-4" }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
+
+    <div>
+      <%= f.label :email, class: "block text-sm font-medium text-gray-700" %>
+      <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "mt-1 w-full rounded border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" %>
+    </div>
+
+    <div>
+      <%= f.label :password, class: "block text-sm font-medium text-gray-700" %>
+      <%= f.password_field :password, autocomplete: "current-password", class: "mt-1 w-full rounded border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" %>
+    </div>
+
+    <% if devise_mapping.rememberable? %>
+      <div class="flex items-center">
+        <%= f.check_box :remember_me, class: "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500" %>
+        <%= f.label :remember_me, class: "ml-2 block text-sm text-gray-900" %>
+      </div>
+    <% end %>
+
+    <div>
+      <%= render Ui::FormButtonComponent.new(form: f, label: 'Log in') %>
+    </div>
+  <% end %>
+  <div class="mt-4 text-center">
+    <%= render "devise/shared/links" %>
+  </div>
+</div>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -1,40 +1,42 @@
 <h1 class="mb-6 text-2xl font-bold">Productos</h1>
 
-<%= form_with url: products_path, method: :get, local: true, class: "mb-4 flex flex-col sm:flex-row" do |form| %>
-  <%= form.text_field :query, value: params[:query], placeholder: "Buscar productos", class: "mb-2 flex-grow rounded border px-3 py-2 sm:mb-0 sm:mr-2 border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" %>
+<%= form_with url: products_path, method: :get, data: { controller: 'search', turbo_frame: 'products' }, class: "mb-4 flex flex-col sm:flex-row" do |form| %>
+  <%= form.text_field :query, value: params[:query], placeholder: "Buscar productos", class: "mb-2 flex-grow rounded border px-3 py-2 sm:mb-0 sm:mr-2 border-gray-300 focus:border-indigo-500 focus:ring-indigo-500", data: { action: 'input->search#search' } %>
   <%= render Ui::FormButtonComponent.new(form: form, label: 'Buscar') %>
 <% end %>
 
-<div class="mb-4 overflow-x-auto">
-<table class="min-w-full divide-y divide-gray-200">
-  <thead class="bg-gray-50">
-    <tr>
-      <th class="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Name</th>
-      <th class="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Price</th>
-      <th class="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Category</th>
-      <th class="px-4 py-2"></th>
-      <th class="px-4 py-2"></th>
-      <th class="px-4 py-2"></th>
-      <th class="px-4 py-2"></th>
-    </tr>
-  </thead>
-
-  <tbody class="divide-y divide-gray-200 bg-white">
-    <% @products.each do |product| %>
+<%= turbo_frame_tag 'products' do %>
+  <div class="mb-4 overflow-x-auto">
+  <table class="min-w-full divide-y divide-gray-200">
+    <thead class="bg-gray-50">
       <tr>
-        <td class="px-4 py-2"><%= product.name %></td>
-        <td class="px-4 py-2"><%= number_to_currency(product.price_cents / 100.0) %></td>
-        <td class="px-4 py-2"><%= product.category.name if product.category %></td>
-        <td class="px-4 py-2"><%= link_to 'Show', product, class: 'text-indigo-600 hover:underline' %></td>
-        <td class="px-4 py-2"><%= link_to 'Edit', edit_product_path(product), class: 'text-indigo-600 hover:underline' %></td>
-        <td class="px-4 py-2"><%= link_to 'Destroy', product, data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' }, class: 'text-red-600 hover:underline' %></td>
-        <td class="px-4 py-2"><%= render Ui::ButtonComponent.new(label: 'Add to Cart', path: add_item_cart_path(product_id: product.id), method: :post) %></td>
+        <th class="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Name</th>
+        <th class="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Price</th>
+        <th class="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Category</th>
+        <th class="px-4 py-2"></th>
+        <th class="px-4 py-2"></th>
+        <th class="px-4 py-2"></th>
+        <th class="px-4 py-2"></th>
       </tr>
-    <% end %>
-  </tbody>
+    </thead>
 
-</table>
-</div>
+    <tbody class="divide-y divide-gray-200 bg-white">
+      <% @products.each do |product| %>
+        <tr>
+          <td class="px-4 py-2"><%= product.name %></td>
+          <td class="px-4 py-2"><%= number_to_currency(product.price_cents / 100.0) %></td>
+          <td class="px-4 py-2"><%= product.category.name if product.category %></td>
+          <td class="px-4 py-2"><%= link_to 'Show', product, class: 'text-indigo-600 hover:underline' %></td>
+          <td class="px-4 py-2"><%= link_to 'Edit', edit_product_path(product), class: 'text-indigo-600 hover:underline' %></td>
+          <td class="px-4 py-2"><%= link_to 'Destroy', product, data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' }, class: 'text-red-600 hover:underline' %></td>
+          <td class="px-4 py-2"><%= render Ui::ButtonComponent.new(label: 'Add to Cart', path: add_item_cart_path(product_id: product.id), method: :post) %></td>
+        </tr>
+      <% end %>
+    </tbody>
+
+  </table>
+  </div>
+<% end %>
 
 <p class="mb-4"><%= link_to 'View Cart', cart_path, class: 'text-indigo-600 hover:underline' %></p>
 

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,0 +1,30 @@
+<div class="mx-auto max-w-md rounded bg-white p-6 shadow">
+  <h2 class="mb-6 text-2xl font-bold text-indigo-600">Sign in</h2>
+  <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "space-y-4" }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
+
+    <div>
+      <%= f.label :email, class: "block text-sm font-medium text-gray-700" %>
+      <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "mt-1 w-full rounded border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" %>
+    </div>
+
+    <div>
+      <%= f.label :password, class: "block text-sm font-medium text-gray-700" %>
+      <%= f.password_field :password, autocomplete: "current-password", class: "mt-1 w-full rounded border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" %>
+    </div>
+
+    <% if devise_mapping.rememberable? %>
+      <div class="flex items-center">
+        <%= f.check_box :remember_me, class: "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500" %>
+        <%= f.label :remember_me, class: "ml-2 block text-sm text-gray-900" %>
+      </div>
+    <% end %>
+
+    <div>
+      <%= render Ui::FormButtonComponent.new(form: f, label: 'Log in') %>
+    </div>
+  <% end %>
+  <div class="mt-4 text-center">
+    <%= render "devise/shared/links" %>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- show cart item count in navbar
- enable live product search via Stimulus and Turbo
- style Devise login forms with Tailwind palette

## Testing
- `bundle exec rubocop` *(fails: bundler: command not found: rubocop)*
- `bundle exec rspec` *(fails: bundler: command not found: rspec)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_6892cddc5db0832ea759e1a19fb8b19d