### PR TITLE
Unify login flow for users and companies

### DIFF
--- a/app/components/layout/navbar_component.html.erb
+++ b/app/components/layout/navbar_component.html.erb
@@ -5,9 +5,12 @@
         <%= link_to "Quick Build", root_path, class: "text-xl font-semibold text-indigo-600" %>
       </div>
       <div class="mt-4 flex flex-col items-center space-y-2 sm:mt-0 sm:flex-row sm:space-y-0 sm:space-x-4">
-        <%= link_to 'Usuarios', new_user_session_path, class: 'text-gray-700 hover:text-indigo-600' %>
-        <%= link_to 'Empresas', new_company_session_path, class: 'text-gray-700 hover:text-indigo-600' %>
         <%= link_to 'Productos', products_path, class: 'text-gray-700 hover:text-indigo-600' %>
+        <% if current_user %>
+          <%= link_to 'Logout', destroy_user_session_path, method: :delete, class: 'text-gray-700 hover:text-indigo-600' %>
+        <% else %>
+          <%= link_to 'Login', new_user_session_path, class: 'text-gray-700 hover:text-indigo-600' %>
+        <% end %>
         <%= link_to cart_path, class: 'relative inline-block text-gray-700 hover:text-indigo-600' do %>
           <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-1.35 2.7a1 1 0 00.9 1.3h12.2M16 16a2 2 0 11-4 0m6 0a2 2 0 11-4 0" />

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@ class ApplicationController < ActionController::Base
   allow_browser versions: :modern
 
   before_action :configure_permitted_parameters, if: :devise_controller?
+  layout :layout_by_role
 
   helper_method :current_cart
   helper_method :cart_items_count
@@ -23,5 +24,9 @@ class ApplicationController < ActionController::Base
 
   def cart_items_count
     current_cart.values.sum
+  end
+
+  def layout_by_role
+    current_user&.seller? ? 'company' : 'application'
   end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,18 @@
+class Users::SessionsController < Devise::SessionsController
+  def create
+    user = User.find_by(email: params[:user][:email])
+    if user&.valid_password?(params[:user][:password])
+      sign_in(:user, user)
+      redirect_to root_path and return
+    end
+
+    flash.now[:alert] = 'Invalid email or password'
+    self.resource = resource_class.new(sign_in_params)
+    render :new, status: :unprocessable_entity
+  end
+
+  def destroy
+    sign_out(:user)
+    redirect_to root_path
+  end
+end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -1,7 +1,5 @@
 class Company < ApplicationRecord
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
   has_many :products, dependent: :destroy
+  has_many :users, dependent: :nullify
+  has_many :stores, dependent: :destroy
 end

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -1,0 +1,3 @@
+class Store < ApplicationRecord
+  belongs_to :company
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,5 +4,8 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
+  belongs_to :company, optional: true
   has_many :orders, dependent: :destroy
+
+  enum role: { buyer: 0, seller: 1 }
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,8 +1,7 @@
 <div class="text-center">
   <h1 class="mb-8 text-3xl font-bold">Bienvenido</h1>
   <div class="flex flex-col items-center space-y-4">
-    <%= render Ui::ButtonComponent.new(label: 'Ingresar como Usuario', path: new_user_session_path) %>
-    <%= render Ui::ButtonComponent.new(label: 'Ingresar como Empresa', path: new_company_session_path) %>
+    <%= render Ui::ButtonComponent.new(label: 'Ingresar', path: new_user_session_path) %>
     <%= render Ui::ButtonComponent.new(label: 'Productos', path: products_path, variant: :secondary) %>
   </div>
 </div>

--- a/app/views/layouts/company.html.erb
+++ b/app/views/layouts/company.html.erb
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title><%= content_for(:title) || "Quick Build Empresas" %></title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="mobile-web-app-capable" content="yes">
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+
+    <%= yield :head %>
+
+    <%# Enable PWA manifest for installable apps (make sure to enable in config/routes.rb too!) %>
+    <%#= tag.link rel: "manifest", href: pwa_manifest_path(format: :json) %>
+
+    <link rel="icon" href="/icon.png" type="image/png">
+    <link rel="icon" href="/icon.svg" type="image/svg+xml">
+    <link rel="apple-touch-icon" href="/icon.png">
+
+    <%# Includes all stylesheet files in app/assets/stylesheets %>
+    <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
+    <%= javascript_importmap_tags %>
+  </head>
+
+  <body class="bg-gray-50 text-gray-900">
+    <%= render Layout::NavbarComponent.new %>
+    <main class="max-w-7xl mx-auto mt-6 px-4">
+      <% if notice %>
+        <p class="mb-4 rounded bg-green-100 p-4 text-green-800"><%= notice %></p>
+      <% end %>
+      <% if alert %>
+        <p class="mb-4 rounded bg-red-100 p-4 text-red-800"><%= alert %></p>
+      <% end %>
+      <%= yield %>
+    </main>
+  </body>
+</html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,5 @@
 Rails.application.routes.draw do
-  devise_for :users
-  devise_for :companies
+  devise_for :users, controllers: { sessions: 'users/sessions' }
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   resource :cart, only: :show do

--- a/db/migrate/20250806060000_add_company_to_users.rb
+++ b/db/migrate/20250806060000_add_company_to_users.rb
@@ -1,0 +1,5 @@
+class AddCompanyToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :users, :company, foreign_key: true
+  end
+end

--- a/db/migrate/20250806060100_create_stores.rb
+++ b/db/migrate/20250806060100_create_stores.rb
@@ -1,0 +1,10 @@
+class CreateStores < ActiveRecord::Migration[7.0]
+  def change
+    create_table :stores do |t|
+      t.string :name
+      t.references :company, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250806060200_add_role_to_users.rb
+++ b/db/migrate/20250806060200_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :role, :integer, default: 0, null: false
+  end
+end


### PR DESCRIPTION
## Summary
- Remove company authentication and rely on user roles instead
- Show company layout when a logged-in user has the `seller` role
- Simplify session handling to sign in and out only users

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec rspec` *(fails: bundler: command not found: rspec)*

------
https://chatgpt.com/codex/tasks/task_e_68983f8a0fc0832e9c81200137590224