### PR TITLE
Support role-based user accounts with Devise

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Overview
+This Rails application is a marketplace for construction materials. It supports four main user flows:
+
+1. **Buyers** – search, compare and purchase materials online.
+2. **Sellers** – company representatives who manage a catalog of materials offered by their company.
+3. **Constructors** – builders who can both purchase materials and manage construction projects in a dedicated dashboard.
+4. **Admins** – owners of the platform with access to administrative features.
+
+Authentication and registration are handled with Devise and must remain compatible with it. Users belong to one of the roles above and seller accounts are associated with a company. The system is designed to support multiple companies (multi‑tenant), each having many users that represent them.
+
+Future features will expand project management for constructors and allow attaching additional roles to users as the platform grows.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    added_attrs = %i[address phone name]
+    added_attrs = %i[address phone name role company_id]
     devise_parameter_sanitizer.permit(:sign_up, keys: added_attrs)
     devise_parameter_sanitizer.permit(:account_update, keys: added_attrs)
   end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -1,7 +1,4 @@
 class Company < ApplicationRecord
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
   has_many :products, dependent: :destroy
+  has_many :users, dependent: :destroy
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,5 +4,10 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
+  belongs_to :company, optional: true
   has_many :orders, dependent: :destroy
+
+  enum role: { buyer: 0, seller: 1, constructor: 2, admin: 3 }
+
+  validates :company, presence: true, if: :seller?
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
-  devise_for :companies
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   resource :cart, only: :show do

--- a/db/migrate/20250806050000_add_role_and_company_to_users.rb
+++ b/db/migrate/20250806050000_add_role_and_company_to_users.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddRoleAndCompanyToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :role, :integer, default: 0, null: false
+    add_reference :users, :company, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_06_040851) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_06_050000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -103,8 +103,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_06_040851) do
     t.datetime "updated_at", null: false
     t.string "address"
     t.string "phone"
+    t.integer "role", default: 0, null: false
+    t.bigint "company_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["company_id"], name: "index_users_on_company_id"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
@@ -114,4 +117,5 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_06_040851) do
   add_foreign_key "orders", "users"
   add_foreign_key "products", "categories"
   add_foreign_key "products", "companies"
+  add_foreign_key "users", "companies"
 end

--- a/spec/factories/companies.rb
+++ b/spec/factories/companies.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :company do
-    name { "Acme S.A." }
+    sequence(:name) { |n| "Company #{n}" }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,20 @@
 FactoryBot.define do
   factory :user do
-    
+    sequence(:email) { |n| "user#{n}@example.com" }
+    password { "password" }
+    role { :buyer }
+
+    trait :seller do
+      role { :seller }
+      association :company
+    end
+
+    trait :constructor do
+      role { :constructor }
+    end
+
+    trait :admin do
+      role { :admin }
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it 'defaults to buyer role' do
+    user = build(:user)
+    expect(user.role).to eq 'buyer'
+  end
+
+  it 'requires a company when role is seller' do
+    user = build(:user, :seller, company: nil)
+    expect(user).not_to be_valid
+    expect(user.errors[:company]).to include("can't be blank")
+  end
+
+  it 'allows an admin without a company' do
+    admin = build(:user, :admin, company: nil)
+    expect(admin).to be_valid
+  end
 end


### PR DESCRIPTION
## Summary
- document admin account role for platform owners
- add admin role to user model and allow admins to exist without a company
- expand tests and factories for admin role

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec rspec` *(fails: bundler: command not found: rspec)*

------
https://chatgpt.com/codex/tasks/task_e_689c0a14644c832ea1a8e9a734e1eba2