### PR TITLE
Add constructor project management with Hotwire

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,0 +1,35 @@
+class ProjectsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :require_constructor!
+
+  def index
+    @projects = current_user.projects
+  end
+
+  def new
+    @project = current_user.projects.build
+  end
+
+  def create
+    @project = current_user.projects.build(project_params)
+    respond_to do |format|
+      if @project.save
+        format.turbo_stream
+        format.html { redirect_to projects_path, notice: 'Project created successfully.' }
+      else
+        format.turbo_stream { render :new, status: :unprocessable_entity }
+        format.html { render :new, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  private
+
+  def require_constructor!
+    redirect_to root_path, alert: 'Not authorized' unless current_user.constructor?
+  end
+
+  def project_params
+    params.require(:project).permit(:name, :location, :start_date, :end_date, :status)
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,0 +1,7 @@
+class Project < ApplicationRecord
+  belongs_to :constructor, class_name: 'User'
+
+  enum status: { planned: 0, in_progress: 1, completed: 2 }
+
+  validates :name, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,7 @@ class User < ApplicationRecord
   belongs_to :company, optional: true
   has_many :orders, dependent: :destroy
 
-  enum :role, [ :buyer, :client, :admin, :seller ]
-  validates :company, presence: true, if: :seller?
+  enum :role, [ :buyer, :client, :admin, :seller, :constructor ]
+  validates :company, presence: true, if: -> { seller? }
+  has_many :projects, foreign_key: :constructor_id, inverse_of: :constructor, dependent: :destroy
 end

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -1,0 +1,27 @@
+<%= form_with model: project, class: 'space-y-4' do |f| %>
+  <div>
+    <%= f.label :name, class: 'block text-sm font-medium' %>
+    <%= f.text_field :name, class: 'mt-1 block w-full border rounded' %>
+  </div>
+  <div>
+    <%= f.label :location, class: 'block text-sm font-medium' %>
+    <%= f.text_field :location, class: 'mt-1 block w-full border rounded' %>
+  </div>
+  <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+    <div>
+      <%= f.label :start_date, class: 'block text-sm font-medium' %>
+      <%= f.date_field :start_date, class: 'mt-1 block w-full border rounded' %>
+    </div>
+    <div>
+      <%= f.label :end_date, class: 'block text-sm font-medium' %>
+      <%= f.date_field :end_date, class: 'mt-1 block w-full border rounded' %>
+    </div>
+  </div>
+  <div>
+    <%= f.label :status, class: 'block text-sm font-medium' %>
+    <%= f.select :status, Project.statuses.keys.map { |s| [s.humanize, s] }, {}, class: 'mt-1 block w-full border rounded' %>
+  </div>
+  <div class="flex justify-end">
+    <%= f.submit 'Save', class: 'bg-blue-500 text-white px-4 py-2 rounded' %>
+  </div>
+<% end %>

--- a/app/views/projects/_project.html.erb
+++ b/app/views/projects/_project.html.erb
@@ -1,0 +1,4 @@
+<div class="p-4 border rounded bg-white">
+  <h2 class="font-semibold"><%= project.name %></h2>
+  <p class="text-sm text-gray-600"><%= project.location %></p>
+</div>

--- a/app/views/projects/create.turbo_stream.erb
+++ b/app/views/projects/create.turbo_stream.erb
@@ -1,0 +1,2 @@
+<%= turbo_stream.prepend 'projects', partial: 'projects/project', locals: { project: @project } %>
+<%= turbo_stream.update 'project_form', '' %>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -1,0 +1,10 @@
+<div class="container mx-auto p-4">
+  <h1 class="text-2xl font-bold mb-4">Projects</h1>
+  <div class="mb-4">
+    <%= link_to 'New Project', new_project_path, data: { turbo_frame: 'project_form' }, class: 'bg-blue-500 text-white px-4 py-2 rounded' %>
+  </div>
+  <div id="projects" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+    <%= render @projects %>
+  </div>
+  <%= turbo_frame_tag 'project_form' %>
+</div>

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -1,0 +1,6 @@
+<%= turbo_frame_tag 'project_form' do %>
+  <div class="max-w-lg mx-auto p-4 bg-white rounded shadow">
+    <h1 class="text-xl font-bold mb-4">New Project</h1>
+    <%= render 'form', project: @project %>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
 
   get 'all_products', to: 'products#all_products', as: :products
   resources :categories
+  resources :projects
 
   get "up" => "rails/health#show", as: :rails_health_check
   root "home#index"

--- a/db/migrate/20250806060000_create_projects.rb
+++ b/db/migrate/20250806060000_create_projects.rb
@@ -1,0 +1,17 @@
+class CreateProjects < ActiveRecord::Migration[8.0]
+  def change
+    create_table :projects do |t|
+      t.string :name, null: false
+      t.string :location
+      t.date :start_date
+      t.date :end_date
+      t.integer :status, default: 0, null: false
+      t.references :constructor, null: false, foreign_key: { to_table: :users }
+
+      t.timestamps
+    end
+
+    add_index :projects, :status
+    add_index :projects, :start_date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_06_050000) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_06_060000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -93,6 +93,20 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_06_050000) do
     t.index ["company_id"], name: "index_products_on_company_id"
   end
 
+  create_table "projects", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "location"
+    t.date "start_date"
+    t.date "end_date"
+    t.integer "status", default: 0, null: false
+    t.bigint "constructor_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["constructor_id"], name: "index_projects_on_constructor_id"
+    t.index ["start_date"], name: "index_projects_on_start_date"
+    t.index ["status"], name: "index_projects_on_status"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -117,5 +131,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_06_050000) do
   add_foreign_key "orders", "users"
   add_foreign_key "products", "categories"
   add_foreign_key "products", "companies"
+  add_foreign_key "projects", "users", column: "constructor_id"
   add_foreign_key "users", "companies"
 end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :project do
+    association :constructor, factory: [:user, :constructor]
+    name { "Sample Project" }
+    location { "Sample City" }
+    start_date { Date.today }
+    end_date { Date.today + 30 }
+    status { :planned }
+  end
+end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe Project, type: :model do
+  it { should belong_to(:constructor).class_name('User') }
+  it { should validate_presence_of(:name) }
+  it { should define_enum_for(:status).with_values(%i[planned in_progress completed]) }
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -12,6 +12,11 @@ RSpec.describe User, type: :model do
     expect(user.errors[:company]).to include("can't be blank")
   end
 
+  it 'allows a constructor without a company' do
+    user = build(:user, :constructor, company: nil)
+    expect(user).to be_valid
+  end
+
   it 'allows an admin without a company' do
     admin = build(:user, :admin, company: nil)
     expect(admin).to be_valid

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -79,4 +79,6 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.include FactoryBot::Syntax::Methods
+  config.include Devise::Test::IntegrationHelpers, type: :request
+  config.include Devise::Test::IntegrationHelpers, type: :system
 end

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe "Projects", type: :request do
+  let(:constructor) { create(:user, :constructor) }
+
+  before do
+    sign_in constructor
+  end
+
+  describe "POST /projects" do
+    it "creates a project" do
+      project_params = {
+        name: "Test",
+        location: "City",
+        start_date: Date.today,
+        end_date: Date.today + 1,
+        status: "planned"
+      }
+      expect {
+        post projects_path, params: { project: project_params }
+      }.to change(Project, :count).by(1)
+      expect(response).to redirect_to(projects_path)
+    end
+  end
+end

--- a/spec/system/projects_spec.rb
+++ b/spec/system/projects_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe "Project management", type: :system do
+  let(:constructor) { create(:user, :constructor) }
+
+  it "allows a constructor to create a project" do
+    sign_in constructor
+    visit projects_path
+    click_link "New Project"
+    fill_in "Name", with: "My Project"
+    fill_in "Location", with: "Town"
+    fill_in "Start date", with: Date.today
+    fill_in "End date", with: Date.today + 1
+    click_button "Save"
+    expect(page).to have_content("My Project")
+  end
+end


### PR DESCRIPTION
## Summary
- remove company association from projects so they belong only to constructors
- allow constructors to exist without a company while still requiring sellers to have one
- update controller, factories, and tests for new project-constructor relationship

## Testing
- `bundle exec rubocop` *(fails: command not found: rubocop)*
- `bundle exec rspec` *(fails: command not found: rspec)*
- `bundle exec rails db:migrate` *(fails: command not found: rails)*

------
https://chatgpt.com/codex/tasks/task_e_68af0a05e130832ebc96502612afd62e